### PR TITLE
An ESPHome package for RS485 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@
 > - PlatformIO plug-in installation: Click on the extension on the left column -> search platformIO -> install the first plug-in
 > - Click Platforms -> Embedded -> search Espressif 32 in the input box -> select the corresponding firmware installation
 
+## ESPHome
+
+Use a package from the [esphome](esphome) directory.
+
 ## Udev Setup (Linux)
 
 If your board isn't present on the device tree, create a file with this content:

--- a/esphome/README.md
+++ b/esphome/README.md
@@ -1,0 +1,25 @@
+ESPHome configuration for LILYGO T-CAN485
+=========================================
+
+The YAML files in this directory are [ESPHome](https://esphome.io) packages that
+make it easy to use configure the T-CAN485 for its main purposes.
+
+Usage example for configuring [a UART
+component](https://esphome.io/components/uart.html) to communicate over RS-485:
+
+```yaml
+packages:
+  lilygo:
+    url: https://github.com/Xinyuan-LilyGO/T-CAN485
+    file: esphome/rs485.yaml
+
+substitutions:
+  # For the `lilygo` package
+  rs485_uart_id: my_uart_id
+
+uart:
+  id: my_uart_id
+  baud_rate: ...
+```
+
+Then add ESPHome components like `modbus` that use the `uart` component.

--- a/esphome/rs485.yaml
+++ b/esphome/rs485.yaml
@@ -1,0 +1,42 @@
+# LILYGO T-CAN485 RS-485
+# ======================
+#
+# This ESPHome configuration file configures a LILYGO T-CAN485 board for
+# performing RS-485 communication. See
+# https://github.com/Xinyuan-LilyGO/T-CAN485 for more details on the hardware.
+#
+# To use this file, include it via the Remote Packages mechanism and set the
+# following in `substitutions`.
+# * `rs485_uart_id`. Mandatory. Set this to match the `id` of a `uart` component
+#   that you add with the same name where you configure the baud rate, parity,
+#   etc., and then attach to higher-level components.
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+uart:
+  id: ${rs485_uart_id}
+  rx_pin: GPIO21
+  tx_pin: GPIO22
+
+# Set pins required for LILYGO T-CAN485 board
+# Source: https://github.com/Xinyuan-LilyGO/T-CAN485/issues/16#issuecomment-1872327090
+# Alternative: https://gist.github.com/Bwooce/7c43622dcc9bc1fbb04d7a0f1e5528df
+output:
+  - platform: gpio
+    id: ENABLE_PIN # Enable the chip
+    pin:
+      number: GPIO19
+      inverted: true
+  - platform: gpio
+    id: SE_PIN # Enable autodirection
+    pin:
+      number: GPIO17
+      inverted: true
+  - platform: gpio
+    id: ENABLE_5V_PIN # Enable 5V pin for RS485 chip
+    pin:
+      number: GPIO16
+      inverted: true


### PR DESCRIPTION
With this PR I'm proposing to create a simple and official way to use the T-CAN485 with [ESPHome](https://esphome.io). Initially there's only a configuration file for RS-485 since that's all I've been able to test. The information that went into `rs485.yaml` came from this repository, but it's spread across old closed issues.

I've already put this configuration file in [a repository of its own](https://github.com/jbj/t-can485-esphome), but I think it's belongs here instead, so I'll archive the other repository if this PR is merged.